### PR TITLE
Hotfix: Entry creation fucks up Item properties

### DIFF
--- a/FATEL_Backend/Domain/ItemWithEntry.cs
+++ b/FATEL_Backend/Domain/ItemWithEntry.cs
@@ -6,6 +6,11 @@ public class ItemWithEntry : Item
     {
         Id = item.Id;
         Name = item.Name;
+        Length = item.Length;
+        Width = item.Width;
+        Unit = item.Unit;
+        Quantity = item.Quantity;
+        Note = item.Note;
         Entry = entry;
     }
     


### PR DESCRIPTION
Fixed the mapping the Item into ItemWithEntry so all the properties are correctly passed