### PR TITLE
MatSideNav component improvements and fixes

### DIFF
--- a/FATEL_Frontend/src/app/inventory/categories/categories.component.css
+++ b/FATEL_Frontend/src/app/inventory/categories/categories.component.css
@@ -137,17 +137,17 @@ tr:not(:last-child) {
 }
 
 .category-action-button:hover {
+  *background-color: #eeecec;
+}
+
+.editing-category {
   background-color: #eeecec;
 }
 
-.editing {
-  background-color: #eeecec;
-}
-
-.editing:hover {
+.editing-category:hover {
   background-color: var(--success);
 }
 
-.editing:hover mat-icon, .deleting:hover mat-icon {
+.editing-category:hover mat-icon, .deleting:hover mat-icon {
   color: var(--white);
-}
+ }

--- a/FATEL_Frontend/src/app/inventory/categories/categories.component.html
+++ b/FATEL_Frontend/src/app/inventory/categories/categories.component.html
@@ -16,7 +16,7 @@
                  (keydown.enter)="$event.stopPropagation();editCategory()"
                  [ngStyle]="{'width.ch': categoryName.length > 32 ? 32 : categoryName.length, 'min-width.ch': 10}"
           >
-          <button mat-button class="category-action-button editing" (click)=$event.stopPropagation();editCategory()>
+          <button mat-button class="category-action-button editing-category" (click)=$event.stopPropagation();editCategory()>
             <mat-icon>check</mat-icon>
           </button>
         </div>

--- a/FATEL_Frontend/src/app/inventory/categories/categories.component.ts
+++ b/FATEL_Frontend/src/app/inventory/categories/categories.component.ts
@@ -58,9 +58,12 @@ export class CategoriesComponent implements OnInit {
 
       this.selectedItem = state.selectedItem;
 
-      if (this.items != state.selectedWarehouse.inventory) {
-        this.items = state.selectedWarehouse.inventory;
-        this.categoriseItems();
+      if (state.selectedWarehouse)
+      {
+        if (this.items != state.selectedWarehouse.inventory) {
+          this.items = state.selectedWarehouse.inventory;
+          this.categoriseItems();
+        }
       }
 
       this.warehouse = state.selectedWarehouse;

--- a/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.html
+++ b/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.html
@@ -45,14 +45,14 @@
         <button class="button" (click)="logout()">
           <mat-icon class="icon logout-icon" aria-hidden="false" aria-label="logout icon">exit_to_app</mat-icon>
         </button>
-        <button class="button" (click)="showDiary()"
+        <button class="button" (click)="showDiary()" *ngIf="warehouseActive !== -1"
         matTooltip="Open Diary"
         matTooltipPosition="right">
           <mat-icon class="icon" aria-hidden="false" aria-label="diary icon" [class.active-icon]="!inventoryActive"
                     [class.inactive-icon]="inventoryActive">event_note
           </mat-icon>
         </button>
-        <button class="button" (click)="showInventory()">
+        <button class="button" (click)="showInventory()" *ngIf="warehouseActive !== -1">
           <mat-icon class="icon" aria-hidden="false" aria-label="inventory icon" [class.active-icon]="inventoryActive"
                     [class.inactive-icon]="!inventoryActive">book
           </mat-icon>

--- a/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
+++ b/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
@@ -85,6 +85,11 @@ export class MatSidenavContainerComponent implements OnInit {
     this.service.create({name: "New Warehouse"}).then(warehouse => {
       console.log("Created warehouse: " + warehouse);
       this.warehouses.push(warehouse);
+      //Select the newly created warehouse, if that is the only one
+      if (this.warehouses.length == 1) {
+        this.warehouseActive = 0;
+        this.store.dispatch(setSelectedWarehouse({warehouse: warehouse}));
+      }
     });
   }
 

--- a/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
+++ b/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
@@ -24,7 +24,7 @@ export class MatSidenavContainerComponent implements OnInit {
   appState = this.store.select('appState');
 
   inventoryActive: boolean = true;
-  warehouseActive: number = 0;
+  warehouseActive: number = -1;
 
   warehouses: Warehouse[] = [];
 
@@ -36,19 +36,27 @@ export class MatSidenavContainerComponent implements OnInit {
       this.warehouses = warehouses;
 
       let firstWarehouse = this.warehouses[0];
+      if (!firstWarehouse) {
+        this.warehouseActive = -1;
+      }
       this.store.dispatch(setSelectedWarehouse({warehouse: firstWarehouse}));
     });
 
     this.appState.subscribe(state => {
+      //If there is no warehouse, does not select either
       if (!state.selectedWarehouse) {
+        this.warehouseActive = -1;
         return;
       }
+      //If a warehouse is deleted (it's name is set to null), select the one before and make the deleted one vanish
       if (state.selectedWarehouse.name == null) {
-        let index = this.warehouses.findIndex(warehouse => warehouse.id == state.selectedWarehouse.id);
-        this.store.dispatch(setSelectedWarehouse({warehouse: this.warehouses[index - 1]}));
+        let index = this.warehouses.findIndex(warehouse => warehouse.id == state.selectedWarehouse.id) - 1;
+        this.store.dispatch(setSelectedWarehouse({warehouse: this.warehouses[index]}));
+        this.warehouseActive = index;
         this.warehouses = this.warehouses.filter(w => w.id != state.selectedWarehouse.id);
         return;
       }
+      //If a warehouse is edited, update the warehouse
       let warehouse = this.warehouses.find(w => w.id == state.selectedWarehouse.id);
       if (!warehouse) {
         return;

--- a/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
+++ b/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
@@ -36,8 +36,7 @@ export class MatSidenavContainerComponent implements OnInit {
       this.warehouses = warehouses;
 
       let firstWarehouse = this.warehouses[0];
-      if (firstWarehouse)
-        this.store.dispatch(setSelectedWarehouse({warehouse: firstWarehouse}));
+      this.store.dispatch(setSelectedWarehouse({warehouse: firstWarehouse}));
     });
 
     this.appState.subscribe(state => {

--- a/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
+++ b/FATEL_Frontend/src/app/mat-sidenav-container/mat-sidenav-container.component.ts
@@ -36,10 +36,8 @@ export class MatSidenavContainerComponent implements OnInit {
       this.warehouses = warehouses;
 
       let firstWarehouse = this.warehouses[0];
-      if (!firstWarehouse) {
-        this.warehouseActive = -1;
-      }
       this.store.dispatch(setSelectedWarehouse({warehouse: firstWarehouse}));
+      this.warehouseActive = this.warehouseActive ? 0 : -1;
     });
 
     this.appState.subscribe(state => {

--- a/FATEL_Frontend/src/app/states/app.states.ts
+++ b/FATEL_Frontend/src/app/states/app.states.ts
@@ -130,10 +130,11 @@ export const reducer = createReducer(
     }
   })),
 
+  //Setting the warehouse name to null triggers the deletion of the warehouse
   on(deleteWarehouseAction, (state, {warehouse}) => ({
     ...state,
     //@ts-ignore
-    selectedWarehouse: {id: warehouse.id, name: null},
+    selectedWarehouse: {id: warehouse.id, name: null, inventory: state.selectedWarehouse.inventory, diary: state.selectedWarehouse.diary}
   }))
 );
 


### PR DESCRIPTION
Fixes:
If there are no warehouses, the no warehouse page shows
When a warehouse is deleted, the previous warehouse is selected and the icon also appears as selected
New:
The diary and inventory icons do not show up if a warehouse is not selected
When the first warehouse is created, it will automatically be selected, after that, no new warehouse will recieve auto selection
Other:
Added comments to clarify the code.